### PR TITLE
feat(macros): support overring rpc method name

### DIFF
--- a/examples/blocking-client.rs
+++ b/examples/blocking-client.rs
@@ -17,6 +17,7 @@ struct MyRpcClient {
 impl MyRpcClient {
     fn sleep(&self, secs: u64) -> Result<u64>;
     fn add(&self, (x, y): (i32, i32), z: i32) -> Result<i32>;
+    #[rpc(name = "@ping")]
     fn ping(&self) -> Result<String>;
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -18,6 +18,7 @@ impl MyRpcClient {
     async fn sleep(&self, secs: u64) -> Result<u64>;
     async fn value(&self) -> Result<u64>;
     async fn add(&self, (x, y): (i32, i32), z: i32) -> Result<i32>;
+    #[rpc(name = "@ping")]
     async fn ping(&self) -> Result<String>;
 }
 

--- a/examples/openrpc.rs
+++ b/examples/openrpc.rs
@@ -34,6 +34,7 @@ trait MyRpc {
     fn echo_my_struct(&self, my_struct: MyStruct) -> Result<MyStruct> {
         Ok(my_struct)
     }
+    #[rpc(name = "@ping")]
     fn ping(&self) -> Result<String> {
         Ok("pong".into())
     }

--- a/examples/server-macros-custom-error.rs
+++ b/examples/server-macros-custom-error.rs
@@ -44,6 +44,7 @@ trait MyRpc {
     async fn sleep(&self, x: u64) -> Result<u64>;
     async fn value(&self, x: Option<u64>) -> Result<u64>;
     async fn add(&self, (x, y): (i32, i32), z: i32) -> Result<i32>;
+    #[rpc(name = "@ping")]
     fn ping(&self) -> Result<String>;
 
     type S: Stream<Item = PublishMsg<u64>> + Send + 'static;

--- a/examples/server-macros.rs
+++ b/examples/server-macros.rs
@@ -15,6 +15,7 @@ trait MyRpc {
     async fn sleep(&self, x: u64) -> Result<u64>;
     async fn value(&self, x: Option<u64>) -> Result<u64>;
     async fn add(&self, (x, y): (i32, i32), z: i32) -> Result<i32>;
+    #[rpc(name = "@ping")]
     fn ping(&self) -> Result<String>;
 
     type S: Stream<Item = PublishMsg<u64>> + Send + 'static;

--- a/tests/server-client.rs
+++ b/tests/server-client.rs
@@ -14,6 +14,7 @@ use serde_json::value::RawValue;
 trait MyRpc {
     async fn sleep(&self, x: u64) -> Result<u64>;
     async fn add(&self, (x, y): (i32, i32), z: i32) -> Result<i32>;
+    #[rpc(name = "@ping")]
     fn ping(&self) -> Result<String>;
 }
 
@@ -44,6 +45,7 @@ struct MyRpcClient {
 impl MyRpcClient {
     async fn sleep(&self, secs: u64) -> anyhow::Result<u64>;
     async fn add(&self, (x, y): (i32, i32), z: i32) -> anyhow::Result<i32>;
+    #[rpc(name = "@ping")]
     async fn ping(&self) -> anyhow::Result<String>;
 }
 
@@ -71,7 +73,7 @@ async fn test_server_client() {
     assert_eq!(
         client
             .inner
-            .rpc("ping", &RawValue::from_string("[]".into()).unwrap())
+            .rpc("@ping", &RawValue::from_string("[]".into()).unwrap())
             .await
             .unwrap(),
         "pong"


### PR DESCRIPTION
 with `#[rpc(name = "actual_name")]`