### PR TITLE
feat: don't enable doc_auto_cfg by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.63.0
           profile: minimal
 
       - uses: actions-rs/toolchain@v1
@@ -33,4 +33,4 @@ jobs:
         run: ./test.sh
 
       - name: MSRV check
-        run: cargo +1.60.0 check --all --all-targets --all-features
+        run: cargo +1.63.0 check --all --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc-utils"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sopium/jsonrpc-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ blocking-client = ["reqwest/blocking", "dep:anyhow"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Alternative pub/sub, server, client and macros for jsonrpc-core.
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub extern crate jsonrpc_core;
 pub extern crate serde_json;


### PR DESCRIPTION
so that downstream crates can build docs using stable rust