### PR TITLE
Add doc for generated methods for missing-docs option

### DIFF
--- a/jsonrpc-utils-macros/src/lib.rs
+++ b/jsonrpc-utils-macros/src/lib.rs
@@ -80,10 +80,12 @@ pub fn rpc(args: TokenStream, input: TokenStream) -> TokenStream {
     let result = quote! {
         #item_trait
 
+        /// Add RPC methods to the given `jsonrpc_utils::jsonrpc_core::MetaIoHandler`.
         #vis fn #add_method_name(rpc: &mut jsonrpc_utils::jsonrpc_core::MetaIoHandler<Option<jsonrpc_utils::pub_sub::Session>>, rpc_impl: impl #trait_name + Clone + Send + Sync + 'static) {
             #(#add_methods)*
         }
 
+        /// Generate OpenRPC document for the RPC methods.
         #doc_func
     };
 


### PR DESCRIPTION
Without these docs, the project use it may trigger this error when run `clippy` with `-D missing-docs`:

```console
error: missing documentation for a function
  --> rpc/src/module/chain.rs:56:1
   |
56 | #[rpc(openrpc)]
   | ^^^^^^^^^^^^^^^
   |
   = note: requested on the command line with `-D missing-docs`
   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `ckb-rpc` (lib) due to previous error
```