### PR TITLE
Add description field to info for rpc trait

### DIFF
--- a/examples/openrpc.rs
+++ b/examples/openrpc.rs
@@ -19,6 +19,7 @@ struct MyStruct {
     z: MyStruct0,
 }
 
+/// This is doc for `MyRpc`.
 #[rpc(openrpc)]
 #[async_trait]
 trait MyRpc {


### PR DESCRIPTION
we need to extract this part of doc:
https://github.com/nervosnetwork/ckb/blob/develop/rpc/src/module/alert.rs#L12-L17

seems it's OK we add it to `info` according to [specs](https://spec.open-rpc.org/#info-object)

This PR reuses the extract description logic from `method_def`.